### PR TITLE
Allow nodeSelector on Crusoe CSI deployments

### DIFF
--- a/charts/crusoe-csi-driver/templates/deployments/controller.yaml
+++ b/charts/crusoe-csi-driver/templates/deployments/controller.yaml
@@ -24,6 +24,10 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $.Values.controller.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with $.Values.controller.topologySpreadConstraints }}
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}

--- a/charts/crusoe-csi-driver/values.yaml
+++ b/charts/crusoe-csi-driver/values.yaml
@@ -29,6 +29,7 @@ crusoe:
 
 controller:
   affinity: { }
+  nodeSelector: { }
   topologySpreadConstraints: [ ]
   tolerations: [ ]
   priorityClassName: "system-cluster-critical"


### PR DESCRIPTION
see also: https://github.com/crusoecloud/crusoe-cloud-controller-manager-helm-charts/pull/1

Allow optional `nodeSelector` on the CSI controller deployments.