### PR TITLE
feat: add configurable updateStrategy for node DaemonSets

### DIFF
--- a/charts/crusoe-csi-driver/templates/daemonsets/node.yaml
+++ b/charts/crusoe-csi-driver/templates/daemonsets/node.yaml
@@ -6,6 +6,10 @@ kind: DaemonSet
 metadata:
   name: {{ include "crusoe-csi-driver.fullname" $ }}-{{ $csiType }}-node
 spec:
+  {{- with $.Values.node.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ include "crusoe-csi-driver.fullname" $ }}-{{ $csiType }}

--- a/charts/crusoe-csi-driver/values.yaml
+++ b/charts/crusoe-csi-driver/values.yaml
@@ -100,6 +100,13 @@ controller:
 node:
   # Extra configuration to add under the daemonset spec
   customSpec: { }
+  # Override the default DaemonSet update strategy (RollingUpdate with maxUnavailable: 1).
+  # Example:
+  #   updateStrategy:
+  #     type: RollingUpdate
+  #     rollingUpdate:
+  #       maxUnavailable: "33%"
+  updateStrategy: { }
   nodeSelector: { }
   # Note that the node agent uses a DaemonSet
   # Only NodeAffinity affinities will affect the scheduling of the node agent


### PR DESCRIPTION
## Summary

- Adds a `node.updateStrategy` value to control the DaemonSet update strategy for node agents
- Defaults to `{}` (Kubernetes default: `RollingUpdate` with `maxUnavailable: 1`)
- Allows operators to set e.g. `maxUnavailable: "33%"` to speed up rollouts on large clusters

## Motivation

During the virtiofs-to-NFS migration, the `install-nfs-prerequisites` init container downloads NFS packages on each node (~6 minutes per node).
With the default `maxUnavailable: 1`, this makes rollouts very slow on clusters with many nodes.
Being able to configure `maxUnavailable` lets operators trade availability for rollout speed.

## Example usage

```yaml
node:
  updateStrategy:
    type: RollingUpdate
    rollingUpdate:
      maxUnavailable: "33%"
```